### PR TITLE
Remove standards.json dependency from MCP plugin

### DIFF
--- a/ai-plugin.json
+++ b/ai-plugin.json
@@ -3,7 +3,7 @@
   "name_for_human": "AL Coding Standards",
   "name_for_model": "al_coding_standards",
   "description_for_human": "Provides TES AL coding guidelines plus a senior reviewer persona and machine-readable standards.",
-  "description_for_model": "Use this plugin to fetch: 1) README.md standards (human), 2) standards.json (machine rules), 3) persona.md (tone/output). Apply these when reviewing AL code and proposing diffs.",
+  "description_for_model": "Use this plugin to fetch: 1) README.md standards (human), 2) persona.md (tone/output). Apply these when reviewing AL code and proposing diffs.",
   "auth": {
     "type": "none"
   },

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -50,24 +50,4 @@ paths:
                     type: string
                     example: "persona.md"
 
-  /standards.json:
-    get:
-      summary: Get machine-readable AL coding standards
-      description: Retrieves a JSON ruleset representing the TES AL coding standards
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  content:
-                    type: string
-                    description: Base64 encoded JSON rules content
-                  encoding:
-                    type: string
-                    example: "base64"
-                  name:
-                    type: string
-                    example: "standards.json"
+


### PR DESCRIPTION
- Updated ai-plugin.json to remove standards.json reference
- Removed /standards.json endpoint from OpenAPI spec
- Simplified MCP plugin to focus on README.md and persona.md only